### PR TITLE
Add new YARA rules for TroyDen campaign detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.DS_Store

--- a/Malware/TroyDen’s Lure Factory/Yara/troyden.yar
+++ b/Malware/TroyDen’s Lure Factory/Yara/troyden.yar
@@ -57,3 +57,59 @@ rule prometheus_obfuscated_lua_payload {
         and $prometheus_env
         and #escape_cluster > 200
 }
+
+
+rule troyden_luajit_runtime_dll {
+    meta:
+        description     = "Detects a custom MinGW-built stripped LuaJIT 2.1 AMD64 runtime DLL; associated with TroyDen campaign split-PE delivery variant: Special thanks to research https://discourse.ifin.network/t/luajit-loader-uses-prometheus-obfuscation-and-etherhiding/679."
+        author          = "vegerland@netskope.com - Netskope Threat Labs"
+        date            = "2026-07-24"
+        threat_name     = "Trojan.LuaJIT.TroyDenCampaign"
+        confidence      = "medium"
+        sample_sha256   = "04d3c82782927330d56827ff551697666dbab4b3abf5b86bde492efdd142bc58"
+    strings:
+          // LuaJIT 2.1 version export name PREFIX -- catches any 2.1.x rev
+          $build_export_prefix = /luaJIT_version_2_1_[0-9]+/
+
+          // MinGW-w64 / MSYS2 compiler signature -- distinguishes custom
+          // MinGW builds from stock MSVC-built LuaJIT releases.
+          $gcc_msys2 = /GCC: \(Rev\d+, Built by MSYS2 project\) \d+\.\d+\.\d+/
+    condition:
+          filesize >= 200KB and filesize <= 800KB
+          and pe.is_pe
+          and pe.machine == pe.MACHINE_AMD64
+          and $build_export_prefix
+          and $gcc_msys2
+}
+
+
+rule troyden_luajit_stub_exe {
+      meta:
+          description     = "Detects a small MinGW-built LuaJIT AMD64 interpreter stub that links lua51.dll -- the split-PE delivery pattern where the actor ships interpreter + DLL separately instead of a monolithic exe; associated with TroyDen campaign split-PE delivery variant: Special thanks to research https://discourse.ifin.network/t/luajit-loader-uses-prometheus-obfuscation-and-etherhiding/679."
+          author          = "vegerland@netskope.com - Netskope Threat Labs"
+          date            = "2026-07-24"
+          threat_name     = "Trojan.LuaJIT.TroyDenCampaign"
+          confidence      = "medium"
+          sample_sha256   = "7ad4b911d05a12f91ab27ba3baa351a56653ca099dda7ad87ee2b94f8cd018c9"
+
+      strings:
+          // LuaJIT identity -- banner string in the .rdata section
+          $luajit_banner = "LuaJIT" ascii
+
+          // MinGW-w64 / MSYS2 compiler signature
+          $gcc_msys2 = /GCC: \(Rev\d+, Built by MSYS2 project\) \d+\.\d+\.\d+/
+
+          // Import library reference to lua51.dll -- proves the stub was
+          // linked against the LuaJIT runtime DLL. Present as an import
+          // directory entry name and as MinGW import library markers
+          // (_head_lua51_dll, lua51_dll_iname).
+          $lua51_import = "lua51.dll" ascii
+
+      condition:
+          filesize < 60KB
+          and pe.is_pe
+          and pe.machine == pe.MACHINE_AMD64
+          and $luajit_banner
+          and $gcc_msys2
+          and $lua51_import
+}


### PR DESCRIPTION
This pull request adds two new YARA rules to improve detection of a split-PE delivery variant used in the TroyDen campaign. These rules specifically target custom MinGW-built LuaJIT AMD64 runtime DLLs and their corresponding interpreter stubs, as documented in recent research; especial thanks to https://discourse.ifin.network/t/luajit-loader-uses-prometheus-obfuscation-and-etherhiding/679.
The additions enhance the ability to identify modular malware delivery techniques associated with this threat actor.